### PR TITLE
feat(uat): migrate ESO IRSA → EKS Pod Identity

### DIFF
--- a/infra/02-uat/README.md
+++ b/infra/02-uat/README.md
@@ -68,7 +68,7 @@ infra/02-uat/local/teardown.sh
 
 ### 1. Terraform
 
-Provisions VPC, EKS, RDS MySQL, Route 53 zone + record, ACM cert, ALB + target group, IRSA for External Secrets. ECR repos live in `infra/00-setup`.
+Provisions VPC, EKS, RDS MySQL, Route 53 zone + record, ACM cert, ALB + target group, and the IAM role + EKS Pod Identity association for External Secrets. ECR repos live in `infra/00-setup`.
 
 ```bash
 cd infra/02-uat/terraform
@@ -102,7 +102,7 @@ infra/02-uat/eks/install.sh
 |------|----------|-------|
 | Namespaces | `argocd`, `uat`, `external-secrets` | from `namespaces.yaml` |
 | Traefik | v34.x via Helm | `NodePort` matching the Terraform ALB target group; registers `IngressClass: traefik` |
-| External Secrets Operator | latest via Helm | IRSA-annotated from Terraform output |
+| External Secrets Operator | latest via Helm | AWS creds via EKS Pod Identity (see below) |
 | Argo CD | v7.8.8 (argo-helm) | `awsAccountId` injected from Terraform |
 
 Argo CD's **ApplicationSet** then deploys all apps (platform, auth-service, score-service, session-service, shooter) automatically from git. Each service gets:
@@ -110,7 +110,19 @@ Argo CD's **ApplicationSet** then deploys all apps (platform, auth-service, scor
 - `env.enabled` = true (mount `<service>-env` Secret)
 - `externalSecret.enabled` = true (ESO creates the Secret from Secrets Manager)
 
-### 3. Post-install
+### 3. Pod Identity (how ESO gets AWS creds)
+
+External Secrets used to rely on **IRSA**: an OIDC provider, a role trust policy tied to a specific service account subject, and the in-cluster `pod-identity-webhook` mutating pods at admission to inject `AWS_WEB_IDENTITY_TOKEN_FILE` + a projected token volume. On this cluster the webhook silently no-opped (`failurePolicy: Ignore`), so the install script had to hand-roll the volume, mount, and env vars — the workaround the README used to call out under "Known issues".
+
+This is now handled with **[EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)**:
+
+- Terraform enables the `eks-pod-identity-agent` EKS managed addon (see `terraform/eks.tf`). The agent runs as a DaemonSet in `kube-system` and serves credentials to pods over a local IMDS-style endpoint.
+- `terraform/iam.tf` defines one IAM role (`uat-external-secrets`) whose trust policy allows `pods.eks.amazonaws.com` with `sts:AssumeRole` + `sts:TagSession`. An `aws_eks_pod_identity_association` binds it to the `external-secrets/external-secrets` service account.
+- The install script no longer passes `extraVolumes` / `extraVolumeMounts` / `extraEnv` for IRSA, and no longer needs the `eks.amazonaws.com/role-arn` annotation on the service account. It does wait for the `eks-pod-identity-agent` DaemonSet to be Ready before installing ESO, so startup failures surface immediately instead of later as `InvalidProviderConfig`.
+
+The OIDC provider is still provisioned (module default) and the role's trust policy still accepts the old IRSA federated principal, so nothing left on IRSA breaks. This is transitional — once everything is confirmed on Pod Identity, the IRSA trust statement and the OIDC provider can be removed.
+
+### 4. Post-install
 
 1. **Check Argo apps sync:** `kubectl get applications -n argocd`
 2. **Confirm ALB target group has healthy targets** (`aws elbv2 describe-target-health ...`).
@@ -131,17 +143,3 @@ infra/02-uat/eks/teardown.sh
 
 Then `terraform -chdir=infra/02-uat/terraform destroy` removes the ALB, ACM cert, Route 53 record, RDS, EKS, and VPC in one go. No more subnet/IGW dependency hangs.
 
----
-
-## Known issues
-
-### IRSA webhook not injecting tokens into ESO pods
-
-**Symptom:** `ClusterSecretStore` shows `InvalidProviderConfig` / `unable to create session: an IAM role must be associated with service account`. The EKS pod-identity-webhook (`127.0.0.1:23443`) exists with `failurePolicy: Ignore` but silently fails to inject the projected service account token and `AWS_*` env vars into pods, even though the OIDC provider and IAM trust policy are correct.
-
-**Current fix:** The install script passes explicit IRSA volume/env overrides to the ESO Helm release (`extraVolumes`, `extraVolumeMounts`, `extraEnv` for `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`, `AWS_REGION`), bypassing the webhook entirely.
-
-**To explore:**
-- Check if installing the `eks-pod-identity-agent` EKS addon resolves the webhook issue (the cluster currently has no managed addons).
-- Check if the webhook works on newer EKS versions (cluster is currently 1.31).
-- Consider switching from IRSA to [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) (simpler, no OIDC provider needed).

--- a/infra/02-uat/eks/install.sh
+++ b/infra/02-uat/eks/install.sh
@@ -26,14 +26,16 @@ TF_DIR="$UAT_DIR/terraform"
 echo "==> Reading Terraform outputs..."
 AWS_ACCOUNT_ID="$(terraform -chdir="$TF_DIR" output -raw aws_account_id)"
 AWS_REGION="$(terraform -chdir="$TF_DIR" output -raw aws_region)"
-IRSA_ROLE_ARN="$(terraform -chdir="$TF_DIR" output -raw external_secrets_irsa_role_arn)"
+# Kept for visibility / debugging; the ESO install no longer consumes it (Pod Identity
+# handles the role binding in Terraform via aws_eks_pod_identity_association).
+ESO_ROLE_ARN="$(terraform -chdir="$TF_DIR" output -raw external_secrets_irsa_role_arn)"
 CLUSTER_NAME="$(terraform -chdir="$TF_DIR" output -raw cluster_name)"
 TRAEFIK_NODEPORT="$(terraform -chdir="$TF_DIR" output -raw traefik_http_nodeport)"
 
 echo "  Account:  $AWS_ACCOUNT_ID"
 echo "  Region:   $AWS_REGION"
 echo "  Cluster:  $CLUSTER_NAME"
-echo "  IRSA ARN: $IRSA_ROLE_ARN"
+echo "  ESO role: $ESO_ROLE_ARN (bound via EKS Pod Identity)"
 echo "  Traefik NodePort: $TRAEFIK_NODEPORT"
 
 # Sanity-check kubectl points at the right cluster.
@@ -50,6 +52,15 @@ fi
 echo ""
 echo "==> Applying namespaces..."
 kubectl apply -f "$UAT_DIR/namespaces.yaml"
+
+# ── 1a. EKS Pod Identity agent ───────────────────────────────────────────────
+# Installed as an EKS managed addon by Terraform (see eks.tf). Workloads get AWS
+# creds via aws_eks_pod_identity_association — no IRSA token projection hackery.
+# Fail fast if the addon DaemonSet isn't healthy, otherwise ESO will just spin
+# on InvalidProviderConfig later.
+echo ""
+echo "==> Waiting for eks-pod-identity-agent DaemonSet to be Ready..."
+kubectl -n kube-system rollout status daemonset/eks-pod-identity-agent --timeout=120s
 
 # ── 2. Traefik ingress controller ────────────────────────────────────────────
 # Service type=NodePort: the Terraform ALB target group forwards to
@@ -73,24 +84,15 @@ helm upgrade --install traefik traefik/traefik \
 echo ""
 echo "==> Installing External Secrets Operator..."
 helm repo add external-secrets https://charts.external-secrets.io --force-update
-# Explicit IRSA volume/env — the EKS pod-identity-webhook silently fails to inject
-# these on some clusters (failurePolicy: Ignore). See README "Known issues".
+# Pod Identity supplies AWS creds directly via the eks-pod-identity-agent
+# DaemonSet + aws_eks_pod_identity_association (see terraform/iam.tf). No
+# serviceAccount annotation, no projected token volume, no AWS_* env wiring —
+# the agent mutates the pod with an IMDS-style credential endpoint at admission.
+# AWS_REGION is still useful so the SDK doesn't have to guess.
 helm upgrade --install external-secrets external-secrets/external-secrets \
   -n external-secrets \
-  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="$IRSA_ROLE_ARN" \
-  --set "extraVolumes[0].name=aws-iam-token" \
-  --set "extraVolumes[0].projected.sources[0].serviceAccountToken.audience=sts.amazonaws.com" \
-  --set "extraVolumes[0].projected.sources[0].serviceAccountToken.expirationSeconds=86400" \
-  --set "extraVolumes[0].projected.sources[0].serviceAccountToken.path=token" \
-  --set "extraVolumeMounts[0].name=aws-iam-token" \
-  --set "extraVolumeMounts[0].mountPath=/var/run/secrets/eks.amazonaws.com/serviceaccount" \
-  --set "extraVolumeMounts[0].readOnly=true" \
-  --set "extraEnv[0].name=AWS_WEB_IDENTITY_TOKEN_FILE" \
-  --set "extraEnv[0].value=/var/run/secrets/eks.amazonaws.com/serviceaccount/token" \
-  --set "extraEnv[1].name=AWS_ROLE_ARN" \
-  --set "extraEnv[1].value=$IRSA_ROLE_ARN" \
-  --set "extraEnv[2].name=AWS_REGION" \
-  --set "extraEnv[2].value=$AWS_REGION" \
+  --set "extraEnv[0].name=AWS_REGION" \
+  --set "extraEnv[0].value=$AWS_REGION" \
   --wait
 
 # ── 4. Argo CD ───────────────────────────────────────────────────────────────

--- a/infra/02-uat/terraform/eks.tf
+++ b/infra/02-uat/terraform/eks.tf
@@ -11,6 +11,15 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
+  # EKS Pod Identity agent — preferred over IRSA (no OIDC round-trip, simpler trust policy).
+  # The old OIDC provider stays provisioned (module default) so existing IRSA roles keep
+  # working during migration; remove once all workloads are on Pod Identity.
+  cluster_addons = {
+    eks-pod-identity-agent = {
+      most_recent = true
+    }
+  }
+
   eks_managed_node_groups = {
     primary = {
       instance_types = ["t3.large"]

--- a/infra/02-uat/terraform/iam.tf
+++ b/infra/02-uat/terraform/iam.tf
@@ -1,4 +1,15 @@
-# IRSA for External Secrets Operator — read app secrets from Secrets Manager (narrow with app-specific policies later).
+# IAM for External Secrets Operator — reads app secrets from Secrets Manager under uat/*.
+#
+# Auth mechanism: **EKS Pod Identity** (see eks-pod-identity-agent addon in eks.tf and the
+# aws_eks_pod_identity_association below). The role's trust policy also still allows the
+# cluster's OIDC provider (IRSA) so anything lingering on the old mechanism keeps working
+# during the migration. Pod Identity takes precedence when both are present, so the
+# service account no longer needs the `eks.amazonaws.com/role-arn` annotation and the
+# install script no longer has to hand-wire `AWS_WEB_IDENTITY_TOKEN_FILE`.
+#
+# TODO: once everything is confirmed on Pod Identity, drop the OIDC statement from the
+# trust policy and remove the OIDC provider from the EKS module.
+
 data "aws_iam_policy_document" "external_secrets" {
   statement {
     sid = "SecretsManagerRead"
@@ -18,22 +29,64 @@ resource "aws_iam_policy" "external_secrets" {
   tags = var.tags
 }
 
-module "irsa_external_secrets" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.47"
+data "aws_iam_policy_document" "external_secrets_trust" {
+  # EKS Pod Identity — the pod-identity-agent exchanges the pod's service-account
+  # credentials for this role. sts:TagSession is required.
+  statement {
+    sid     = "PodIdentity"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
 
-  role_name = "uat-external-secrets"
-
-  role_policy_arns = {
-    secrets = aws_iam_policy.external_secrets.arn
-  }
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["external-secrets:external-secrets"]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
     }
   }
+
+  # IRSA (OIDC) — kept for backward compatibility while migrating. Safe to delete along
+  # with the OIDC provider once Pod Identity is verified end-to-end.
+  statement {
+    sid     = "IRSA"
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:external-secrets:external-secrets"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "external_secrets" {
+  name               = "uat-external-secrets"
+  assume_role_policy = data.aws_iam_policy_document.external_secrets_trust.json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "external_secrets" {
+  role       = aws_iam_role.external_secrets.name
+  policy_arn = aws_iam_policy.external_secrets.arn
+}
+
+# Bind the role to the external-secrets/external-secrets service account via Pod Identity.
+resource "aws_eks_pod_identity_association" "external_secrets" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "external-secrets"
+  service_account = "external-secrets"
+  role_arn        = aws_iam_role.external_secrets.arn
 
   tags = var.tags
 }

--- a/infra/02-uat/terraform/outputs.tf
+++ b/infra/02-uat/terraform/outputs.tf
@@ -70,8 +70,13 @@ output "rds_endpoint" {
 
 
 output "external_secrets_irsa_role_arn" {
-  description = "Annotate the external-secrets service account with eks.amazonaws.com/role-arn"
-  value       = module.irsa_external_secrets.iam_role_arn
+  description = "IAM role ARN for the external-secrets SA. Bound via EKS Pod Identity (see aws_eks_pod_identity_association.external_secrets); the name is kept for backward compat with install.sh."
+  value       = aws_iam_role.external_secrets.arn
+}
+
+output "external_secrets_role_arn" {
+  description = "Alias of external_secrets_irsa_role_arn. Prefer this name going forward; the IRSA-suffixed one is a transitional alias."
+  value       = aws_iam_role.external_secrets.arn
 }
 
 output "aws_account_id" {


### PR DESCRIPTION
## Summary

- Replace the IRSA + `pod-identity-webhook` wiring for External Secrets with **EKS Pod Identity**. Closes the "IRSA webhook not injecting tokens into ESO pods" TODO in `infra/02-uat/README.md` (was in "Known issues / To explore").
- Terraform now installs the `eks-pod-identity-agent` EKS managed addon, rewrites the ESO IAM role with a `pods.eks.amazonaws.com` trust policy, and creates an `aws_eks_pod_identity_association` binding it to `external-secrets/external-secrets`.
- `infra/02-uat/eks/install.sh` drops the `extraVolumes` / `extraVolumeMounts` / `extraEnv` IRSA workaround and the `eks.amazonaws.com/role-arn` SA annotation; it now waits on the `eks-pod-identity-agent` DaemonSet before installing ESO so failures surface early.
- README: "Known issues: IRSA webhook" removed; new "Pod Identity" subsection under EKS deployment documents the new flow.

## Design notes / risks

- **Trust policy coexistence.** The ESO role trusts *both* `pods.eks.amazonaws.com` (Pod Identity) and the cluster's OIDC provider (IRSA) for now. Pod Identity takes precedence when both mechanisms are present, so active pods will use it; the IRSA statement is a safety net while migrating. The OIDC provider itself (created by the EKS module) is left in place — callout in the README and a TODO in `iam.tf` mark it for future removal.
- **Output compat.** `external_secrets_irsa_role_arn` is kept (install.sh reads it) but now points at the new native role; added `external_secrets_role_arn` as a forward-compat alias. Anything else reading the old output keeps working.
- **Addon version.** Using `most_recent = true` for `eks-pod-identity-agent` — AWS picks the newest compatible build for the cluster version. Pin a specific `addon_version` in a follow-up if reproducibility matters.
- **Region env.** ESO still gets `AWS_REGION` via `extraEnv` because the SDK otherwise has to guess; all the IRSA-specific env + projected token volume entries are gone.

## Verification

- `terraform fmt` — clean.
- `terraform init -backend=false` + `terraform validate` — Success.
- No live cluster ops performed per task constraints; runtime smoke (ESO `ClusterSecretStore` Ready, ESO pod `aws sts get-caller-identity` returning the role) to happen on next apply.

## Test plan

- [ ] `terraform apply` on a UAT cluster; confirm `eks-pod-identity-agent` DaemonSet is Ready in `kube-system` and the `aws_eks_pod_identity_association` lands.
- [ ] Run `infra/02-uat/eks/install.sh`; ESO pods come up without the old `extraVolumes` wiring.
- [ ] `kubectl -n external-secrets get clustersecretstore` reports Ready (no `InvalidProviderConfig`).
- [ ] Exec into the ESO pod and confirm `aws sts get-caller-identity` returns the `uat-external-secrets` role assumed via Pod Identity (not web-identity).
- [ ] Follow-up PR: drop the IRSA trust statement and the OIDC provider once the above is green in UAT.


Made with [Cursor](https://cursor.com)